### PR TITLE
Mise en commentaire du code permettant d'avoir la couche en édition s…

### DIFF
--- a/web/js/directives/formDirectives.js
+++ b/web/js/directives/formDirectives.js
@@ -583,7 +583,9 @@ app.directive('geometry', function($timeout){
             }
 
             var cat = $scope.options.dataUrl.split("/")[1];
-            mapService.getLayerControl().addOverlay($scope.editLayer, "Edition");
+            // NF 2 : la ligne ci-dessous permet d'avoir la couche en édition présente dans la légende
+            // afin de jouer avec la visibilité
+            // mapService.getLayerControl().addOverlay($scope.editLayer, "Edition");
             mapService.showLayer(cat).then(function(){
                 var layer = mapService.selectItem($scope.origin, cat);
                 if(layer){


### PR DESCRIPTION
…ur la légende

Pour avoir la couche en édition sur la légende, décommenter la ligne 588 dans formDirective.js
Mais il y a une issue associée, c'est à dire que la couche en édition se dupliquait dès qu'on ajoute un nouvel élément puisque la légende qui est liée à la carte n'est pas recréée à chaque chargement de page.
Si cette fonctionnalité est remise, voir comment supprimer la couche en édition dans la légende une fois le nouvel élément enregistré.